### PR TITLE
Add build:local to package.json scripts

### DIFF
--- a/pages-updater.js
+++ b/pages-updater.js
@@ -56,7 +56,8 @@ const updatePackageScripts = (targetDirectory) => {
     const packageJson = require(packageJsonPath);
     packageJson.scripts = {
       "dev": "pages dev",
-      "prod": "pages prod"
+      "prod": "pages prod",
+      "build:local": "pages build"
     };
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
     console.log('package.json scripts updated.');


### PR DESCRIPTION
TEST=manual

Ran on a fresh install of sites-starter-react-locations

After updating, I can successfully run npm run prod without error.